### PR TITLE
Update Go versions; dep now requires Go 1.8+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go:
-- 1.7
 - 1.8
+- 1.9
 install:
 - go get -u github.com/golang/dep/cmd/dep
 - dep ensure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-- Add items here as needed.
+- Update build to test with Go 1.9, drop support for 1.7 since `dep` now
+  requires Go 1.8+. Go 1.7 users can still use this library but must manage
+  their own dependencies.
 
 ## [1.1.0] - 2017-08-01
 


### PR DESCRIPTION
This PR is because of this [failed test](https://travis-ci.org/istreamlabs/go-metrics/jobs/269743141), which in turn is due to [`dep`](https://github.com/golang/dep#dep) now requiring Go 1.8 or newer. I also threw in 1.9 since it has been released.