### PR TITLE
Fix typos found by misspell.

### DIFF
--- a/metrics/query.go
+++ b/metrics/query.go
@@ -34,7 +34,7 @@ type Query interface {
 	Accept()
 
 	// GetCalls returns the currently matching list of calls. The calls may be
-	// cast to `MetricCall` or `EventCall` for futher processing.
+	// cast to `MetricCall` or `EventCall` for further processing.
 	GetCalls() []Call
 
 	// MinTimes sets the minimum number of calls that should be left before

--- a/metrics/recorder.go
+++ b/metrics/recorder.go
@@ -351,7 +351,7 @@ func (c *RecorderClient) ExpectContains(component string) Query {
 //   // This will not fail, because the bad tag is not found.
 //   recorder.If("my.metric").Tag("bad", "tag").Reject()
 //
-//   // This will fail becasue the metric is found.
+//   // This will fail because the metric is found.
 //   recorder.If("my.metric").Reject()
 //
 //   // The following are equivalent, but the first is preferred.


### PR DESCRIPTION
Minor spelling fix for the issues found here:

https://goreportcard.com/report/github.com/istreamlabs/go-metrics