### PR TITLE
Add WithRate method to DataDog client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update build to test with Go 1.9, drop support for 1.7 since `dep` now
   requires Go 1.8+. Go 1.7 users can still use this library but must manage
   their own dependencies.
+- Add `WithRate(rate float)` to the DataDog client to limit traffic sent to
+  the `dogstatsd` daemon. The set rate will be applied to all calls made
+  with the returned `Client`.
 
 ## [1.1.0] - 2017-08-01
 

--- a/metrics/datadog.go
+++ b/metrics/datadog.go
@@ -10,6 +10,7 @@ import (
 // DataDogClient is a dogstatsd metrics client implementation.
 type DataDogClient struct {
 	client *statsd.Client
+	rate   float64
 	tagMap map[string]string
 }
 
@@ -29,6 +30,16 @@ func NewDataDogClient(address string, namespace string) *DataDogClient {
 
 	return &DataDogClient{
 		client: c,
+		rate:   1.0,
+	}
+}
+
+// WithRate clones this client with a new sample rate.
+func (c *DataDogClient) WithRate(rate float64) Client {
+	return &DataDogClient{
+		client: c.client,
+		rate:   rate,
+		tagMap: combine(c.tagMap, map[string]string{}),
 	}
 }
 
@@ -37,6 +48,7 @@ func NewDataDogClient(address string, namespace string) *DataDogClient {
 func (c *DataDogClient) WithTags(tags map[string]string) Client {
 	return &DataDogClient{
 		client: c.client,
+		rate:   c.rate,
 		tagMap: combine(c.tagMap, tags),
 	}
 }
@@ -47,7 +59,7 @@ func (c *DataDogClient) tagsList() []string {
 
 // Count adds some integer value to a metric.
 func (c *DataDogClient) Count(name string, value int64) {
-	c.client.Count(name, value, c.tagsList(), 1.0)
+	c.client.Count(name, value, c.tagsList(), c.rate)
 }
 
 // Incr adds one to a metric.
@@ -62,7 +74,7 @@ func (c *DataDogClient) Decr(name string) {
 
 // Gauge sets a numeric value.
 func (c *DataDogClient) Gauge(name string, value float64) {
-	c.client.Gauge(name, value, c.tagsList(), 1.0)
+	c.client.Gauge(name, value, c.tagsList(), c.rate)
 }
 
 // Event tracks an event that may be relevant to other metrics.
@@ -72,10 +84,10 @@ func (c *DataDogClient) Event(e *statsd.Event) {
 
 // Timing tracks a duration.
 func (c *DataDogClient) Timing(name string, value time.Duration) {
-	c.client.Timing(name, value, c.tagsList(), 1)
+	c.client.Timing(name, value, c.tagsList(), c.rate)
 }
 
 // Histogram sets a numeric value while tracking min/max/avg/p95/etc.
 func (c *DataDogClient) Histogram(name string, value float64) {
-	c.client.Histogram(name, value, c.tagsList(), 1.0)
+	c.client.Histogram(name, value, c.tagsList(), c.rate)
 }

--- a/metrics/datadog_test.go
+++ b/metrics/datadog_test.go
@@ -9,6 +9,10 @@ import (
 	"github.com/istreamlabs/go-metrics/metrics"
 )
 
+type withRater interface {
+	WithRate(rate float64) metrics.Client
+}
+
 func ExampleDataDogClient() {
 	datadog := metrics.NewDataDogClient("127.0.0.1:8125", "myprefix")
 	datadog.WithTags(map[string]string{
@@ -35,6 +39,13 @@ func TestDataDogClient(t *testing.T) {
 	datadog.Decr("one")
 	datadog.Gauge("memory", 1024)
 	datadog.Histogram("histo", 123)
+
+	if rater, ok := datadog.(withRater); ok {
+		ratedClient := rater.WithRate(0.5)
+		ratedClient.Incr("rated")
+	} else {
+		t.Fatalf("Expected DataDog client to support sample rate")
+	}
 
 	// Test that tag overrides work.
 	override := datadog.WithTags(map[string]string{


### PR DESCRIPTION
This adds a `WithRate(rate float64) metrics.Client` method to the `DataDogClient` which applies the sample rate to all subsequent calls. It didn't make much sense adding it to other clients, so for now it is specific to the DataDog one.

There are two ways to use it to e.g. send only 50% of the metrics over the wire:

```go
// Simple way applies to *all* metrics
client := metrics.NewDataDogClient("localhost:8125", "test").WithRate(0.5)
client.Count("foo", 123)

// --- --- --- ---

// Given any `metrics.Client` you can test it via an interface and only rate limit
// when you want to.
type Rater interface {
    WithRate(rate float64) metrics.Client
}

// Do not rate limit errors.
client.Incr("some-error")

// Rate limit some counter if possible.
if rater, ok := client.(Rater); ok {
    // Client can be rated
    rater.WithRate(0.5).Count("foo", 123)
} else {
    client.Count("foo", 123)
}
```

This functionality is useful for metrics that would generate too much traffic and can still be useful if sampled at a low rate.