### PR TITLE
Add tags to events automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update build to test with Go 1.9, drop support for 1.7 since `dep` now
   requires Go 1.8+. Go 1.7 users can still use this library but must manage
   their own dependencies.
+- Automatically assign tags to events.
 
 ## [1.1.0] - 2017-08-01
 

--- a/metrics/datadog.go
+++ b/metrics/datadog.go
@@ -67,6 +67,10 @@ func (c *DataDogClient) Gauge(name string, value float64) {
 
 // Event tracks an event that may be relevant to other metrics.
 func (c *DataDogClient) Event(e *statsd.Event) {
+	if len(c.tagMap) > 0 {
+		e.Tags = append(e.Tags, c.tagsList()...)
+	}
+
 	c.client.Event(e)
 }
 

--- a/metrics/datadog_test.go
+++ b/metrics/datadog_test.go
@@ -52,4 +52,17 @@ func TestDataDogClient(t *testing.T) {
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf("Expected %v to equal %v", actual, expected)
 	}
+
+	// Events should get tags assigned automatically.
+	e := &statsd.Event{
+		Title: "Test event",
+	}
+
+	datadog.WithTags(map[string]string{
+		"tag1": "value1",
+	}).Event(e)
+
+	if !reflect.DeepEqual(e.Tags, []string{"tag1:value1"}) {
+		t.Fatalf("Expected event to have tags '[tag1:value1]'. Found '%v'", e.Tags)
+	}
 }


### PR DESCRIPTION
Currently events ignore tags set on the metrics client. This fixes that bug by modifying the event with the configured tags on the client before sending.