### PR TITLE
Add colorized log output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
         recorder.WithRate(0.1).Count("foo", 5)
         recorder.Expect("foo").Rate(0.1).Value(5)
         ```
+- Add `Colorized()` method to `LoggerClient`, and automatically detect a TTY and enable color when `nil` is passed to the `NewLoggerClient` constructor.
 
 ## [1.2.0] - 2018-03-01
 

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -7,9 +7,33 @@
   revision = "0ddda6bee21174ef6c4873647cb0d6ec9cba996f"
   version = "1.1.0"
 
+[[projects]]
+  name = "github.com/mattn/go-colorable"
+  packages = ["."]
+  revision = "167de6bfdfba052fa6b2d3664c8f5272e23c9072"
+  version = "v0.0.9"
+
+[[projects]]
+  name = "github.com/mattn/go-isatty"
+  packages = ["."]
+  revision = "0360b2af4f38e8d38c7fce2a9f4e702702d73a39"
+  version = "v0.0.3"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/mgutz/ansi"
+  packages = ["."]
+  revision = "9520e82c474b0a04dd04f8a40959027271bab992"
+
+[[projects]]
+  branch = "master"
+  name = "golang.org/x/sys"
+  packages = ["unix"]
+  revision = "89ac7f292d17a339edab4de8efcba5d8672ff661"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "3c464e93d9484bd21a6f4142b027464e61b05565238d35751f3a71fdbd221f87"
+  inputs-digest = "4db059a1ef5c652b313ba622691ff47fd95edea6f6e2c5e4202b98bc5f689010"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/metrics/logger.go
+++ b/metrics/logger.go
@@ -1,12 +1,25 @@
 package metrics
 
 import (
+	"fmt"
 	"log"
 	"math/rand"
 	"os"
 	"time"
 
 	"github.com/DataDog/datadog-go/statsd"
+	"github.com/mattn/go-isatty"
+	"github.com/mgutz/ansi"
+)
+
+var (
+	// Colors are from the ANSI 256 color pallette.
+	// https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit
+	cname    = ansi.ColorFunc("208")
+	cvalue   = ansi.ColorFunc("32")
+	crate    = ansi.ColorFunc("106")
+	csampled = ansi.ColorFunc("43")
+	ctag     = ansi.ColorFunc("133")
 )
 
 // InfoLogger provides a method for logging info messages and is implemented
@@ -19,22 +32,46 @@ type InfoLogger interface {
 // locally for testing. Can be used with multiple different logging systems.
 type LoggerClient struct {
 	logger InfoLogger
+	colors bool
 	rate   float64
 	tagMap map[string]string
 }
 
 // NewLoggerClient creates a new logging client. If `logger` is `nil` then it
-// defaults to stdout using the built-in `log` package. It is equivalent to:
+// defaults to stdout using the built-in `log` package. It is equivalent to
+// the following with added auto-detection for colorized output:
 //
 //   metrics.NewLoggerClient(log.New(os.Stdout, "", 0))
+//
+// You can use your own logger and enable colorized output manually via:
+//
+//   metrics.NewLoggerClient(myLog).Colorized()
 func NewLoggerClient(logger InfoLogger) *LoggerClient {
+	colors := false
 	if logger == nil {
 		logger = log.New(os.Stdout, "", 0)
+
+		if isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd()) {
+			colors = true
+		}
 	}
 
-	return &LoggerClient{
+	client := &LoggerClient{
 		logger: logger,
+		colors: colors,
 		rate:   1.0,
+	}
+
+	return client
+}
+
+// Colorized enables colored terminal output.
+func (c *LoggerClient) Colorized() *LoggerClient {
+	return &LoggerClient{
+		logger: c.logger,
+		rate:   c.rate,
+		colors: true,
+		tagMap: combine(map[string]string{}, c.tagMap),
 	}
 }
 
@@ -44,6 +81,7 @@ func (c *LoggerClient) WithTags(tags map[string]string) Client {
 	return &LoggerClient{
 		logger: c.logger,
 		rate:   c.rate,
+		colors: c.colors,
 		tagMap: combine(c.tagMap, tags),
 	}
 }
@@ -54,24 +92,54 @@ func (c *LoggerClient) WithRate(rate float64) Client {
 	return &LoggerClient{
 		logger: c.logger,
 		rate:   rate,
+		colors: c.colors,
 		tagMap: combine(map[string]string{}, c.tagMap),
 	}
 }
 
 // print out the metric call, taking into account sample rate.
 func (c *LoggerClient) print(t string, name string, value interface{}, sampled interface{}) {
+	r := fmt.Sprintf("%v", c.rate)
+	v := value
+	s := sampled
+
+	if c.colors {
+		name = cname(name)
+		r = crate(r)
+		v = cvalue(fmt.Sprintf("%v", value))
+		s = csampled(fmt.Sprintf("%v", sampled))
+	}
+
 	if c.rate == 1.0 {
-		c.logger.Printf("%s %s:%v %v", t, name, value, c.tagMap)
+		c.logger.Printf("%s %s:%v %v", t, name, v, c.getTags())
 		return
 	}
 
 	if rand.Float64() < c.rate {
 		if value == sampled {
-			c.logger.Printf("%s %s:%v (%v) %v", t, name, value, c.rate, c.tagMap)
+			c.logger.Printf("%s %s:%v (%v) %v", t, name, v, r, c.getTags())
 		} else {
-			c.logger.Printf("%s %s:%v (%v * %v) %v", t, name, sampled, value, c.rate, c.tagMap)
+			c.logger.Printf("%s %s:%v (%v * %v) %v", t, name, s, v, r, c.getTags())
 		}
 	}
+}
+
+func (c *LoggerClient) getTags() string {
+	if !c.colors {
+		return fmt.Sprintf("%v", c.tagMap)
+	}
+
+	tags := ""
+
+	for name, value := range c.tagMap {
+		if tags != "" {
+			tags += " "
+		}
+
+		tags += fmt.Sprintf("%s:%s", ctag(name), value)
+	}
+
+	return "map[" + tags + "]"
 }
 
 // Count adds some value to a metric.

--- a/metrics/logger_test.go
+++ b/metrics/logger_test.go
@@ -59,4 +59,8 @@ func TestLoggerClient(t *testing.T) {
 	sampled := client.WithRate(0.8)
 	sampled.Incr("sampled")
 	sampled.Incr("sampled")
+
+	// Test colorized output
+	client.(*metrics.LoggerClient).Colorized().Incr("colored")
+	ExpectEqual(t, "Count \x1b[38;5;208mcolored\x1b[0m:\x1b[38;5;32m1\x1b[0m map[]", recorder.messages[len(recorder.messages)-1])
 }


### PR DESCRIPTION
This builds on the code changes in #6 and adds autodetected colorized output for the `LoggerClient`, which is easier to read when running locally for manual testing:

<img width="254" alt="screen shot 2018-03-15 at 11 56 23 am" src="https://user-images.githubusercontent.com/22035690/37488329-84635028-2851-11e8-9d62-ff5399a0257d.png">
