### PR TITLE
Make recorder error message more useful

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 - Put unreleased items here.
 
+## [1.3.1] - 2018-05-14
+
+- Add more helpful error message when `WithTest(t)` is not called on the recorder metrics client during testing.
+
 ## [1.3.0] - 2018-03-19
 
 - Add `WithRate(float64)` to the metrics interface and to all clients that implement

--- a/metrics/recorder.go
+++ b/metrics/recorder.go
@@ -265,7 +265,7 @@ func (c *RecorderClient) Length() int {
 // output message to help with debugging.
 func (c *RecorderClient) Fatalf(format string, args ...interface{}) {
 	if c.test == nil {
-		panic("No test associated with metrics recorder")
+		panic("No test associated with metrics recorder, you must call `recorder.WithTest(t)`")
 	}
 	// blacklist contains a set of fully qualified function name components that
 	// we will filter out to keep the call stack concise.


### PR DESCRIPTION
This should prevent confusion by telling you which method should have been invoked and how, which the dev can then look up in the docs for more information.