### PR TITLE
Test on Go 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ go:
 - 1.8
 - 1.9
 - '1.10'
+- '1.11'
 install:
 - go get -u github.com/golang/dep/cmd/dep
 - dep ensure


### PR DESCRIPTION
Currently this still uses `dep`. Apparently it's [possible to use Go Modules](https://dave.cheney.net/2018/07/16/using-go-modules-with-travis-ci) but I'll leave that to another PR.