### PR TITLE
Fix last release version to 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 - Put unreleased items here.
 
-## [2.0.0] - 2020-05-28
+## [1.5.0] - 2020-05-28
 
 - Go module support
 - Go 1.12-1.14 support


### PR DESCRIPTION
I had initially planned to make this release 2.0.0 but, in hindsight, it is not necessary and should be 1.5.0 instead. The changes to the API are additive only and even the addition of the `Close` method doesn't necessitate a major version update. 