### PR TITLE
refactor(perf): improve tag serialization

### DIFF
--- a/metrics/util.go
+++ b/metrics/util.go
@@ -32,7 +32,7 @@ func cloneTagsWithMap(original []string, newTags map[string]string) []string {
 
 	i := len(original)
 	for k, v := range newTags {
-		combined[i] = fmt.Sprintf("%s:%s", k, v)
+		combined[i] = buildTag(k, v)
 		i++
 	}
 
@@ -44,10 +44,19 @@ func mapToStrings(tagMap map[string]string) []string {
 	tags := make([]string, 0, len(tagMap))
 
 	for k, v := range tagMap {
-		tags = append(tags, fmt.Sprintf("%s:%s", k, v))
+		tags = append(tags, buildTag(k, v))
 	}
 
 	return tags
+}
+
+func buildTag(k, v string) string {
+	var b strings.Builder
+	b.Grow(len(k) + len(v) + 1)
+	b.WriteString(k)
+	b.WriteByte(':')
+	b.WriteString(v)
+	return b.String()
 }
 
 // convertType converts a value into an specific type if possible, otherwise


### PR DESCRIPTION
Benchmark changes:

```
benchmark                                       old ns/op     new ns/op     delta
Benchmark_0Tags_100Emits-4                      30814         28782         -6.59%
BenchmarkTags_5Tags_100Emits-4                  42317         53051         +25.37%
BenchmarkTags_5Tags_100Emits_WithInline-4       143681        107949        -24.87%
BenchmarkTags_10Tags_1000Emits-4                989118        526336        -46.79%
BenchmarkTags_10Tags_1000Emits_WithInline-4     2449188       1372939       -43.94%
BenchmarkTags_15Tags_100Emits-4                 77491         69507         -10.30%
BenchmarkTags_15Tags_100Emits_WithInline-4      190324        156984        -17.52%

benchmark                                       old allocs     new allocs     delta
Benchmark_0Tags_100Emits-4                      1              1              +0.00%
BenchmarkTags_5Tags_100Emits-4                  17             7              -58.82%
BenchmarkTags_5Tags_100Emits_WithInline-4       717            507            -29.29%
BenchmarkTags_10Tags_1000Emits-4                32             12             -62.50%
BenchmarkTags_10Tags_1000Emits_WithInline-4     7032           5012           -28.73%
BenchmarkTags_15Tags_100Emits-4                 47             17             -63.83%
BenchmarkTags_15Tags_100Emits_WithInline-4      747            517            -30.79%

benchmark                                       old bytes     new bytes     delta
Benchmark_0Tags_100Emits-4                      48            48            +0.00%
BenchmarkTags_5Tags_100Emits-4                  370           211           -42.97%
BenchmarkTags_5Tags_100Emits_WithInline-4       51900         48528         -6.50%
BenchmarkTags_10Tags_1000Emits-4                751           401           -46.60%
BenchmarkTags_10Tags_1000Emits_WithInline-4     595994        563601        -5.44%
BenchmarkTags_15Tags_100Emits-4                 1012          534           -47.23%
BenchmarkTags_15Tags_100Emits_WithInline-4      68543         64851         -5.39%
```