### PR TITLE
feat: add option for custom configured statsd client

### DIFF
--- a/metrics/datadog.go
+++ b/metrics/datadog.go
@@ -31,6 +31,9 @@ func WithoutTelemetry() Option {
 	}
 }
 
+// WithStatsd sets a custom configured statsd client. This lets you set any
+// options that aren't directly supported by the metrics package. When used,
+// this ignores the address and namespace arguments to NewDataDogClient.
 func WithStatsd(s *statsd.Client) Option {
 	return func(o *Options) error {
 		o.Statsd = s


### PR DESCRIPTION
This enables sending in your own statsd client with any options you want rather than having to duplicate them all into go-metrics.

Datadog v5 introduced client-side aggregation by default, and [5.1.1](https://github.com/DataDog/datadog-go/blob/master/CHANGELOG.md#511--2022-05-05) fixed a bug where tags could be modified after being submitted (the fix is to copy the slices around). Together, these can introduce a lot of CPU / memory overhead, as can be seen in this example profiler snippet, where as load increases almost all of the additional memory used (~900MB of the 1000MB) is in Datadog's statsd during the client-side aggregation:

<img width="549" alt="Screen Shot 2023-02-22 at 16 11 40" src="https://user-images.githubusercontent.com/106826/220792984-088d58d5-0d80-48ec-ae82-7bab53956fac.png">

Aside from enabling clients to opt in or out of that feature, this change enables service owners to experiment with other options as needed without additional changes to this library.

Benchmarks added to show the effect of the client-side aggregation option:

```
goos: darwin
goarch: arm64
pkg: github.com/istreamlabs/go-metrics/metrics
BenchmarkTags_15Tags_1000Emits_Incr-10              7088  171911 ns/op  224530 B/op	    1017 allocs/op
BenchmarkTags_15Tags_1000Emits_Incr_WithInline-10   2976  386977 ns/op  883741 B/op	    6017 allocs/op
BenchmarkTags_15Tags_1000Emits_Incr_NoAggr-10       4286  246955 ns/op     545 B/op	      17 allocs/op
PASS
ok  	github.com/istreamlabs/go-metrics/metrics	4.609s
```